### PR TITLE
Bump minimum julia version and fix a couple of precompilation tests

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.7.0-beta.85
+julia 0.7.0-beta2.199
 OrderedCollections

--- a/src/Revise.jl
+++ b/src/Revise.jl
@@ -1,5 +1,3 @@
-__precompile__(true)
-
 module Revise
 
 using FileWatching, REPL, Base.CoreLogging, Distributed

--- a/test/common.jl
+++ b/test/common.jl
@@ -1,8 +1,9 @@
 using Random
 
+const setseed = @static VERSION >= v"0.7.0-beta2.171" ? Random.seed! : srand
 const rseed = Ref(Random.GLOBAL_RNG)  # to get new random directories (see #24445)
 function randtmp()
-    srand(rseed[])
+    setseed(rseed[])
     dirname = joinpath(tempdir(), randstring(10))
     rseed[] = Random.GLOBAL_RNG
     dirname

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -234,6 +234,7 @@ Method signatures:
         push!(LOAD_PATH, testdir)
         for (pcflag, fbase) in ((true, "pc"), (false, "npc"))  # precompiled & not
             modname = uppercase(fbase)
+            pcexpr = pcflag ? nothing : :(__precompile__(false))
             # Create a package with the following structure:
             #   src/PkgName.jl   # PC.jl = precompiled, NPC.jl = nonprecompiled
             #   src/file2.jl
@@ -244,8 +245,7 @@ Method signatures:
             mkpath(dn)
             open(joinpath(dn, modname*".jl"), "w") do io
                 println(io, """
-__precompile__($pcflag)
-
+$pcexpr
 module $modname
 
 export $(fbase)1, $(fbase)2, $(fbase)3, $(fbase)4, $(fbase)5, using_macro_$(fbase)
@@ -300,7 +300,7 @@ end
             # Change the definition of function 1 (easiest to just rewrite the whole file)
             open(joinpath(dn, modname*".jl"), "w") do io
                 println(io, """
-__precompile__($pcflag)
+$pcexpr
 module $modname
 export $(fbase)1, $(fbase)2, $(fbase)3, $(fbase)4, $(fbase)5, using_mac$(fbase)
 $(fbase)1() = -1
@@ -426,8 +426,6 @@ end
         mkpath(dn)
         open(joinpath(dn, "ModFILE.jl"), "w") do io
             println(io, """
-__precompile__()
-
 module ModFILE
 
 mf() = @__FILE__, 1
@@ -441,8 +439,6 @@ end
         sleep(0.1)
         open(joinpath(dn, "ModFILE.jl"), "w") do io
             println(io, """
-__precompile__()
-
 module ModFILE
 
 mf() = @__FILE__, 2
@@ -642,6 +638,7 @@ end
         mkpath(dn)
         open(joinpath(dn, "MethDel.jl"), "w") do io
             println(io, """
+__precompile__(false)   # "clean" Base doesn't have :revisefoo
 module MethDel
 f(x) = 1
 f(x::Int) = 2
@@ -892,7 +889,7 @@ end
             @test repo != nothing
             files = Revise.git_files(repo)
             @test "README.md" ∈ files
-            src = Revise.git_source(loc, "HEAD")
+            src = Revise.git_source(loc, "946d588328c2eb5fe5a56a21b4395379e41092e0")
             @test startswith(src, "__precompile__")
             src = Revise.git_source(loc, "eae5e000097000472280e6183973a665c4243b94") # 2nd commit in Revise's history
             @test src == "module Revise\n\n# package code goes here\n\nend # module\n"


### PR DESCRIPTION
Thanks for https://github.com/timholy/Revise.jl/pull/119. Do you know about this?
```sh
~/src/julia-1.0$ contrib/commit-name.sh 6026374bce093fbc69ee9a58916505a86a6afe80
0.7.0-beta2.199
```

This still won't pass tests until https://github.com/JuliaLang/julia/issues/28384 is fixed. But I've run this with the corresponding PR locally and it now passes tests. So I don't see any reason we can't merge this now.

If you merge this into your fork it should add it to your PR.